### PR TITLE
Fix sales table layout with horizontal scroll wrapper

### DIFF
--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2966,7 +2966,7 @@ export default function Sales() {
                   <TableHead>{t("common.date")}</TableHead>
                   <TableHead>{t("common.amount")}</TableHead>
                   <TableHead>{t("common.status")}</TableHead>
-                  <TableHead className="text-right">{t("common.actions")}</TableHead>
+                  <TableHead>{t("common.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -3034,8 +3034,8 @@ export default function Sales() {
                       </div>
                     </TableCell>
                     <TableCell>{getStatusBadge(invoice.status)}</TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex gap-1 justify-end">
+                    <TableCell>
+                      <div className="flex gap-1">
                         <Button
                           variant="outline"
                           size="sm"

--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2957,7 +2957,7 @@ export default function Sales() {
         <CardContent>
           <div className="hidden md:block">
             <div className="w-full overflow-x-auto">
-              <Table className="min-w-[1100px] [&_th]:px-6 [&_td]:px-6 whitespace-nowrap">
+              <Table className="w-full sm:min-w-0 [&_th]:px-4 [&_td]:px-4 md:[&_th]:px-6 md:[&_td]:px-6">
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("sales.invoice_number")}</TableHead>

--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2956,7 +2956,16 @@ export default function Sales() {
         </CardHeader>
         <CardContent>
           <div className="hidden md:block">
-            <Table className="min-w-[1100px] [&_th]:px-6 [&_td]:px-6 lg:[&_th]:px-8 lg:[&_td]:px-8 whitespace-nowrap">
+            <Table className="w-full table-fixed [&_th]:px-4 [&_td]:px-4 lg:[&_th]:px-6 lg:[&_td]:px-6 whitespace-nowrap">
+              <colgroup>
+                <col className="w-[13%]" />
+                <col className="w-[18%]" />
+                <col className="w-[18%]" />
+                <col className="w-[16%]" />
+                <col className="w-[12%]" />
+                <col className="w-[11%]" />
+                <col className="w-[12%]" />
+              </colgroup>
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("sales.invoice_number")}</TableHead>
@@ -2965,7 +2974,7 @@ export default function Sales() {
                   <TableHead>{t("common.date")}</TableHead>
                   <TableHead>{t("common.amount")}</TableHead>
                   <TableHead>{t("common.status")}</TableHead>
-                  <TableHead>{t("common.actions")}</TableHead>
+                  <TableHead className="text-right">{t("common.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -3033,8 +3042,8 @@ export default function Sales() {
                       </div>
                     </TableCell>
                     <TableCell>{getStatusBadge(invoice.status)}</TableCell>
-                    <TableCell>
-                      <div className="flex gap-1">
+                    <TableCell className="text-right">
+                      <div className="flex gap-1 justify-end">
                         <Button
                           variant="outline"
                           size="sm"

--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2956,7 +2956,7 @@ export default function Sales() {
         </CardHeader>
         <CardContent>
           <div className="hidden md:block">
-            <Table>
+            <Table className="min-w-[1100px] [&_th]:px-6 [&_td]:px-6 lg:[&_th]:px-8 lg:[&_td]:px-8 whitespace-nowrap">
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("sales.invoice_number")}</TableHead>

--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2958,160 +2958,162 @@ export default function Sales() {
           <div className="hidden md:block">
             <div className="w-full overflow-x-auto">
               <Table className="w-full sm:min-w-0 [&_th]:px-4 [&_td]:px-4 md:[&_th]:px-6 md:[&_td]:px-6">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("sales.invoice_number")}</TableHead>
-                  <TableHead>{t("sales.client")}</TableHead>
-                  <TableHead>{t("employees.employee")}</TableHead>
-                  <TableHead>{t("common.date")}</TableHead>
-                  <TableHead>{t("common.amount")}</TableHead>
-                  <TableHead>{t("common.status")}</TableHead>
-                  <TableHead>{t("common.actions")}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedInvoices.map((invoice) => (
-                  <TableRow key={invoice.id}>
-                    <TableCell className="font-medium">
-                      {invoice.invoiceNumber}
-                    </TableCell>
-                    <TableCell>
-                      <div>
-                        <div className="font-medium">{invoice.clientName}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {invoice.clientEmail}
-                        </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-2">
-                        {invoice.employeeName ? (
-                          <>
-                            <Avatar className="h-6 w-6">
-                              <AvatarImage
-                                src={invoice.employeeAvatar}
-                                alt={invoice.employeeName}
-                              />
-                              <AvatarFallback className="text-xs">
-                                {invoice.employeeName
-                                  .split(" ")
-                                  .map((n) => n[0])
-                                  .join("")
-                                  .toUpperCase()}
-                              </AvatarFallback>
-                            </Avatar>
-                            <span className="text-sm">
-                              {invoice.employeeName}
-                            </span>
-                          </>
-                        ) : (
-                          <span className="text-sm text-muted-foreground">
-                            {t("sales.no_employee")}
-                          </span>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div>
-                        <div>
-                          {new Intl.DateTimeFormat(i18n.language || "en", {
-                            year: "numeric",
-                            month: "2-digit",
-                            day: "2-digit",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                            second: "2-digit",
-                          }).format(new Date(invoice.date))}
-                        </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div className="font-medium">
-                        ${invoice.total.toFixed(2)}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {t(`sales.${invoice.paymentMethod}`)}
-                      </div>
-                    </TableCell>
-                    <TableCell>{getStatusBadge(invoice.status)}</TableCell>
-                    <TableCell>
-                      <div className="flex gap-1">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => {
-                            setSelectedInvoice(invoice);
-                            setIsViewDialogOpen(true);
-                          }}
-                        >
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => {
-                            toast({
-                              title: "Invoice downloaded",
-                              description:
-                                "Invoice PDF has been generated and downloaded.",
-                            });
-                          }}
-                        >
-                          <Download className="h-4 w-4" />
-                        </Button>
-                        {invoice.status === "draft" && (
-                          <>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={updatingIds.has(invoice.id)}
-                              onClick={() =>
-                                updateInvoiceStatus(invoice.id, "sent")
-                              }
-                            >
-                              {t("sales.send")}
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={updatingIds.has(invoice.id)}
-                              onClick={() => openCancelDialog(invoice)}
-                              className="text-red-600 hover:text-red-700"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </>
-                        )}
-                        {invoice.status === "sent" && (
-                          <>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={updatingIds.has(invoice.id)}
-                              onClick={() =>
-                                updateInvoiceStatus(invoice.id, "paid")
-                              }
-                              className="text-green-600"
-                            >
-                              {t("sales.mark_paid")}
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={updatingIds.has(invoice.id)}
-                              onClick={() => openCancelDialog(invoice)}
-                              className="text-red-600 hover:text-red-700"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </>
-                        )}
-                      </div>
-                    </TableCell>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("sales.invoice_number")}</TableHead>
+                    <TableHead>{t("sales.client")}</TableHead>
+                    <TableHead>{t("employees.employee")}</TableHead>
+                    <TableHead>{t("common.date")}</TableHead>
+                    <TableHead>{t("common.amount")}</TableHead>
+                    <TableHead>{t("common.status")}</TableHead>
+                    <TableHead>{t("common.actions")}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {sortedInvoices.map((invoice) => (
+                    <TableRow key={invoice.id}>
+                      <TableCell className="font-medium">
+                        {invoice.invoiceNumber}
+                      </TableCell>
+                      <TableCell>
+                        <div>
+                          <div className="font-medium">
+                            {invoice.clientName}
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            {invoice.clientEmail}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {invoice.employeeName ? (
+                            <>
+                              <Avatar className="h-6 w-6">
+                                <AvatarImage
+                                  src={invoice.employeeAvatar}
+                                  alt={invoice.employeeName}
+                                />
+                                <AvatarFallback className="text-xs">
+                                  {invoice.employeeName
+                                    .split(" ")
+                                    .map((n) => n[0])
+                                    .join("")
+                                    .toUpperCase()}
+                                </AvatarFallback>
+                              </Avatar>
+                              <span className="text-sm">
+                                {invoice.employeeName}
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">
+                              {t("sales.no_employee")}
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div>
+                          <div>
+                            {new Intl.DateTimeFormat(i18n.language || "en", {
+                              year: "numeric",
+                              month: "2-digit",
+                              day: "2-digit",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            }).format(new Date(invoice.date))}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="font-medium">
+                          ${invoice.total.toFixed(2)}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {t(`sales.${invoice.paymentMethod}`)}
+                        </div>
+                      </TableCell>
+                      <TableCell>{getStatusBadge(invoice.status)}</TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              setSelectedInvoice(invoice);
+                              setIsViewDialogOpen(true);
+                            }}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              toast({
+                                title: "Invoice downloaded",
+                                description:
+                                  "Invoice PDF has been generated and downloaded.",
+                              });
+                            }}
+                          >
+                            <Download className="h-4 w-4" />
+                          </Button>
+                          {invoice.status === "draft" && (
+                            <>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={updatingIds.has(invoice.id)}
+                                onClick={() =>
+                                  updateInvoiceStatus(invoice.id, "sent")
+                                }
+                              >
+                                {t("sales.send")}
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={updatingIds.has(invoice.id)}
+                                onClick={() => openCancelDialog(invoice)}
+                                className="text-red-600 hover:text-red-700"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </>
+                          )}
+                          {invoice.status === "sent" && (
+                            <>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={updatingIds.has(invoice.id)}
+                                onClick={() =>
+                                  updateInvoiceStatus(invoice.id, "paid")
+                                }
+                                className="text-green-600"
+                              >
+                                {t("sales.mark_paid")}
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={updatingIds.has(invoice.id)}
+                                onClick={() => openCancelDialog(invoice)}
+                                className="text-red-600 hover:text-red-700"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           </div>
 

--- a/client/pages/Sales.tsx
+++ b/client/pages/Sales.tsx
@@ -2956,16 +2956,8 @@ export default function Sales() {
         </CardHeader>
         <CardContent>
           <div className="hidden md:block">
-            <Table className="w-full table-fixed [&_th]:px-4 [&_td]:px-4 lg:[&_th]:px-6 lg:[&_td]:px-6 whitespace-nowrap">
-              <colgroup>
-                <col className="w-[13%]" />
-                <col className="w-[18%]" />
-                <col className="w-[18%]" />
-                <col className="w-[16%]" />
-                <col className="w-[12%]" />
-                <col className="w-[11%]" />
-                <col className="w-[12%]" />
-              </colgroup>
+            <div className="w-full overflow-x-auto">
+              <Table className="min-w-[1100px] [&_th]:px-6 [&_td]:px-6 whitespace-nowrap">
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("sales.invoice_number")}</TableHead>
@@ -3120,6 +3112,7 @@ export default function Sales() {
                 ))}
               </TableBody>
             </Table>
+            </div>
           </div>
 
           <div className="md:hidden space-y-3">


### PR DESCRIPTION
## Purpose

Based on user feedback, this change addresses layout issues in the sales management table where:
- Actions column was positioned too far from other columns, requiring horizontal scrolling to access
- Table layout appeared inconsistent compared to other sections like transaction history
- Users needed to swipe left/right to reach action buttons, creating poor UX

The goal is to improve table accessibility and visual consistency while maintaining proper spacing.

## Code changes

- Wrapped the sales table in a `div` with `w-full overflow-x-auto` class to enable horizontal scrolling
- Added responsive padding classes to table headers and cells: `[&_th]:px-4 [&_td]:px-4 md:[&_th]:px-6 md:[&_td]:px-6`
- Applied `w-full sm:min-w-0` classes to the Table component for better responsive behavior
- Maintained all existing table functionality while improving layout and spacing

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5e1de49b065d46bc8d70fa050695c851/pulse-field)

👀 [Preview Link](https://5e1de49b065d46bc8d70fa050695c851-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5e1de49b065d46bc8d70fa050695c851</projectId>-->
<!--<branchName>pulse-field</branchName>-->